### PR TITLE
Generate merit profiles in SVG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := build
 
-#.PHONY: build test
+.PHONY: depend run clean build test release
 
 VERSION=$(shell git describe --tags --always)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -132,11 +132,15 @@ The --terminal parameter only applies to the gnuplot format.
 		} else if "gnuplot-opinion" == format || "gnuplot_opinion" == format {
 			outputFormatter = &formatter.GnuplotOpinionFormatter{}
 		} else if "svg" == format {
-			panic(
-				"Unsupported format." + "\n" +
-					"Try with   --format gnuplot --terminal svg   instead?" + "\n" +
-					"See issue https://github.com/MieuxVoter/majority-judgment-cli/issues/11",
-			)
+			if "merit" == chart {
+				outputFormatter = &formatter.SvgMeritFormatter{}
+			} else {
+				panic(
+					"The svg format is only supported for merit profiles." + "\n" +
+						"Try with   --format gnuplot --terminal svg   instead?" + "\n" +
+						"See issue https://github.com/MieuxVoter/majority-judgment-cli/issues/11",
+				)
+			}
 		} else {
 			fmt.Printf("Format `%s` is not supported.  Supported formats: text, csv, json, yaml, gnuplot\n", format)
 			os.Exit(errorConfiguring)

--- a/formatter/csv.go
+++ b/formatter/csv.go
@@ -13,7 +13,7 @@ type CsvFormatter struct{}
 
 // Format the provided results
 func (t *CsvFormatter) Format(
-	pollTally *judgment.PollTally,
+	_ *judgment.PollTally,
 	result *judgment.PollResult,
 	proposals []string,
 	grades []string,

--- a/formatter/csv.go
+++ b/formatter/csv.go
@@ -26,6 +26,7 @@ func (t *CsvFormatter) Format(
 
 	buffer := new(bytes.Buffer)
 	writer := csv.NewWriter(buffer)
+	defer writer.Flush()
 
 	if err := writer.Error(); err != nil {
 		log.Fatal(err)
@@ -57,8 +58,6 @@ func (t *CsvFormatter) Format(
 		}
 
 	}
-
-	writer.Flush() // I've also seen "defer" prefixed here.  Gotta RTFM
 
 	return buffer.String(), nil
 }

--- a/formatter/gnuplot_merit.go
+++ b/formatter/gnuplot_merit.go
@@ -27,6 +27,7 @@ func (t *GnuplotMeritFormatter) Format(
 
 	buffer := new(bytes.Buffer)
 	writer := csv.NewWriter(buffer)
+	defer writer.Flush()
 
 	if err := writer.Error(); err != nil {
 		log.Fatal(err)
@@ -57,7 +58,6 @@ func (t *GnuplotMeritFormatter) Format(
 			log.Fatal(writeErr)
 		}
 	}
-	writer.Flush()
 
 	plotHeight := 350 + 24*len(proposals)
 

--- a/formatter/gnuplot_opinion.go
+++ b/formatter/gnuplot_opinion.go
@@ -38,6 +38,7 @@ func (t *GnuplotOpinionFormatter) Format(
 
 	buffer := new(bytes.Buffer)
 	writer := csv.NewWriter(buffer)
+	defer writer.Flush()
 
 	if err := writer.Error(); err != nil {
 		log.Fatal(err)
@@ -67,8 +68,6 @@ func (t *GnuplotOpinionFormatter) Format(
 			log.Fatal(writeErr)
 		}
 	}
-
-	writer.Flush()
 
 	plotWidth := 400 + 90*len(grades)
 

--- a/formatter/svg_merit.go
+++ b/formatter/svg_merit.go
@@ -1,0 +1,41 @@
+package formatter
+
+import (
+	"github.com/mieuxvoter/majority-judgment-library-go/judgment"
+	"github.com/mieuxvoter/merit-profile-library-go/merit"
+	"image/color"
+)
+
+// SvgMeritFormatter renders merit profiles as SVG
+type SvgMeritFormatter struct{}
+
+// Format the provided results in the gnuplot script form
+func (t *SvgMeritFormatter) Format(
+	_ *judgment.PollTally,
+	result *judgment.PollResult,
+	proposals []string,
+	_ []string,
+	options *Options,
+) (string, error) {
+	proposalsResults := result.Proposals
+	if options.Sorted {
+		proposalsResults = result.ProposalsSorted
+	}
+
+	svgProposals := make([]merit.Proposal, len(proposalsResults))
+
+	for i, pr := range proposalsResults {
+		svgProposal := merit.Proposal{
+			Name:  proposals[proposalsResults[i].Index],
+			Tally: pr.Tally.Tally,
+		}
+		svgProposals[i] = svgProposal
+	}
+
+	svg, err := merit.RenderLinearProfileSVG(
+		svgProposals,
+		merit.WithBgColor(color.NRGBA{R: 13, G: 13, B: 13, A: 255}),
+	)
+
+	return svg, err
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/csimplestring/go-csv v0.0.0-20180328183906-5b8b3cd94f2c
 	// The amazing Majority Judgment lib made by the goated devs of MieuxVoter
 	github.com/mieuxvoter/majority-judgment-library-go v0.3.3
+	// The beautiful merit profile lib made by the same goats
+	github.com/mieuxvoter/merit-profile-library-go v1.1.0
 	// We use it to get the color profiles of the user's terminal
 	github.com/muesli/termenv v0.16.0
 	// Cobra & Viper are the CLI app framework we use
@@ -22,11 +24,12 @@ require (
 )
 
 require (
+	github.com/ajstarks/gensvg v0.0.0-20210923152200-4042c242e95e // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect


### PR DESCRIPTION
We can now generate SVG merit profiles.

### By example

```bash
./mj example/example03.csv --format svg
```

<img width="1040" height="548" alt="image" src="https://github.com/user-attachments/assets/e30d8616-8e93-42eb-8b48-7bc2e6706a6b" />
